### PR TITLE
Fixed double finishing orders

### DIFF
--- a/src/PizzaBar/helpers/OrderHelper.java
+++ b/src/PizzaBar/helpers/OrderHelper.java
@@ -145,7 +145,10 @@ public class OrderHelper {
             System.out.println("No order with id " + id);
             return;
         }
-
+        if (o.getStatus() == Order.Status.FINISHED) {
+            System.out.println("Order #" + id + " already marked as finished. Skipping...");
+            return;
+        }
         o.finish();
         try {
             fh.appendOrderFinished(o);


### PR DESCRIPTION
## Hvad
Fixer en bug hvor man kan markere en order som finished flere gange.

## Tjekliste
- [x] Meningsfulde navne/kommentarer
- [x] Ingen ubrugt kode
- [x] Konsol-output pænt og konsistent

## Test
*(Hvis relevant)*
- [x] Kørte lokalt uden exceptions
- [x] Manuel test (trin/resultat):
- [x] Edge cases håndteret
